### PR TITLE
Add fallback icon for CSV split

### DIFF
--- a/src/flet_datascope_test.py
+++ b/src/flet_datascope_test.py
@@ -41,6 +41,11 @@ app_busy = False
 # Default chunk size for CSV splitting operations
 CHUNK_SIZE_DEFAULT = 256
 
+# Icon to represent CSV splitting. Older versions of this file referenced
+# ``ft.Icon.SPLIT_CSV_OUTLINE`` which does not exist in Flet.  We gracefully
+# fall back to ``HORIZONTAL_SPLIT_OUTLINED`` to avoid runtime errors.
+SPLIT_CSV_ICON = getattr(ft.Icons, "SPLIT_CSV_OUTLINE", ft.Icons.HORIZONTAL_SPLIT_OUTLINED)
+
 # Control references
 dialog_controls = {
     "output_text_field": None,
@@ -586,7 +591,7 @@ async def transition_to_gui(page: ft.Page):
                             dialog_controls["chunk_size_input"],
                             ft.ElevatedButton(
                                 text="Chunk CSV",
-                                icon=ft.Icons.HORIZONTAL_SPLIT_OUTLINED,
+                                icon=SPLIT_CSV_ICON,
                                 on_click=on_chunk_csv,
                             ),
                         ],


### PR DESCRIPTION
## Summary
- prevent icon errors for CSV chunk button by providing a fallback icon

## Testing
- `python -m py_compile src/flet_datascope_test.py`
- `python -m py_compile src/data_handler.py src/logging_handler.py src/visual_analyst.py`

------
https://chatgpt.com/codex/tasks/task_e_687aa194c3248326acfc7f019c38a44f